### PR TITLE
Report Web Vitals to GoogleAnalytics

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -55,6 +55,8 @@ jobs:
             yarn install
             yarn test -- --coverage
         popd
+      env:
+        REACT_APP_GA_CODE: "UA-129704402-1"
 
     # Coverage badges will be updated on any branch
     # and saved into a dedicated one
@@ -162,6 +164,8 @@ jobs:
             yarn install
             yarn build
         popd
+      env:
+        REACT_APP_GA_CODE: "UA-129704402-1"
 
     - name: Deploy to GitHub Pages
       if: success()

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -14,7 +14,7 @@ import available from './i18n/available';
 
 import AppMenu from './AppMenu';
 import ModalRouter from './ModalRouter';
-import GAListener from './GAListener';
+import GAListener, {ReportWebVitals} from './GAListener';
 import ErrorCatcher from './ErrorCatcher';
 import { Live, ByDate } from './Players';
 import Cookies from './Cookies';
@@ -23,6 +23,9 @@ import Help from './Help';
 import botCheck from './botCheck';
 
 import './App.css';
+
+// GoogleAnalytics code taken from env
+const GACode = process.env.REACT_APP_GA_CODE;
 
 // Template function for catching errors from components
 const withErrorCatcher = (origin, component) => <ErrorCatcher {...{ origin , key: origin }}>{ component }</ErrorCatcher>;
@@ -49,7 +52,12 @@ const AppProviders = function(props) {
       <HelmetProvider>
         <Router>
           {/* GoogleAnalytics event provider and route change detector */}
-          <GAListener language={ props.language } trackOptIn={ props.trackOptIn } >
+          <GAListener
+            GACode={ props.GACode }
+            language={ props.language }
+            trackOptIn={ props.trackOptIn }
+          >
+            <ReportWebVitals/>
             <div className='App' id='router-container'>
               { props.children }
             </div>
@@ -108,6 +116,7 @@ class App extends React.Component {
     });
   }
 
+
   render() {
     const date = new Date();
     const todayStr = `/${date.getFullYear()}/${1 + date.getMonth()}/${date.getDate()}/0/0`;
@@ -120,6 +129,7 @@ class App extends React.Component {
           translations,
           language,
           trackOptIn,
+          GACode,
         }}
       >
 

--- a/app/src/GAListener/GAListener.jsx
+++ b/app/src/GAListener/GAListener.jsx
@@ -8,23 +8,33 @@ import GAListenerActive from './GAListenerActive';
 // Renders GA+children in production, only children for the rest
 class GAListener extends React.Component {
 
-  createEvent = (origin, help, status) => {
-    const event = {
-      category: origin,
-      action: help,
-    };
+  createEvent = (...args) => {
+    const event = {};
 
-    if ( typeof status === 'string' ) {
-      console.log(status);
-      event.label = status;
+    if(args.length > 1) {
+      // Generate a React-GA event from arguments
+      const [origin, help, status] = args;
+      Object.assign(event, {
+        category: origin,
+        action: help,
+      });
+
+      if ( typeof status === 'string' ) {
+        event.label = status;
+      }
+    }
+    else {
+      // Arguments is already a React-GA event
+      Object.assign(event, args[0]);
     }
 
-    console.log(event);
+    console.log("event:", event);
 
     return event;
   }
 
-  sendEvent = (...args) => ReactGA.event( this.createEvent(...args) );
+  sendEvent = (...args) =>
+    ReactGA.event( this.createEvent(...args) );
 
   render() {
     const { children, trackOptIn, ...props } = this.props;

--- a/app/src/GAListener/ReportWebVitals.jsx
+++ b/app/src/GAListener/ReportWebVitals.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import withGAEvent from './withGAEvent';
+
+// Returns a function which uses `sendEvent`
+// to send webVitals events to GA
+// See `/index.js`
+const handleWebVitals = (sendEvent) =>
+  // Send webVitals to GA
+  // Use `event.detail` to get webVitals details
+  ({detail: { id, name, value }}) => {
+    // https://create-react-app.dev/docs/measuring-performance/
+    sendEvent({
+      category: 'Web Vitals',
+      action: name,
+      value: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+      label: id, // id unique to current page load
+      nonInteraction: true, // avoids affecting bounce rate
+    });
+  }
+
+// Simple functional component to (un)subscribe from document
+// event listener `webVitals` (see `/index.js` )
+const ReportWebVitals = ({sendEvent}) => {
+  React.useEffect( () => {
+    const listener = handleWebVitals(sendEvent);
+    document.addEventListener('webVitals', listener);
+    return () => document.removeEventListener('webVitals', listener);
+  }, [sendEvent]);
+
+  return null;
+}
+
+export default withGAEvent(ReportWebVitals);

--- a/app/src/GAListener/index.js
+++ b/app/src/GAListener/index.js
@@ -1,5 +1,6 @@
 import GAListener from './GAListener';
 import withGAEvent from './withGAEvent';
+import ReportWebVitals from './ReportWebVitals';
 
-export { withGAEvent };
+export { withGAEvent, ReportWebVitals };
 export default GAListener;

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -6,6 +6,13 @@ import App from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 
+// Creates a custom event and fires it on the document
+// Internal components can listen to it
+const dispatchCustomEvent = (name, detail) => {
+  const event = new CustomEvent(name, { detail });
+  document.dispatchEvent(event);
+}
+
 // Callback to call when user accepts loading new service worker
 // - Send message to SW to trigger the update
 // - Once updated, reload this window to load new assets
@@ -46,9 +53,9 @@ serviceWorkerRegistration.register({
 
   // When new ServiceWorker is available, trigger an event on `document`,
   // passing `registration` as extra data
+  // Send message to internal components through document custom event
   onUpdate: (registration) => {
-    var event = new CustomEvent('onNewServiceWorker', { detail: { registration } });
-    document.dispatchEvent(event);
+    dispatchCustomEvent('onNewServiceWorker', { registration });
   }
 
 });
@@ -56,4 +63,5 @@ serviceWorkerRegistration.register({
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+// Send message to internal components through document custom event
+reportWebVitals( args => dispatchCustomEvent('webVitals', args ) );

--- a/app/src/reportWebVitals.js
+++ b/app/src/reportWebVitals.js
@@ -1,12 +1,12 @@
+import { getCLS, getFID, getFCP, getLCP, getTTFB } from 'web-vitals';
+
 const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    getCLS(onPerfEntry);
+    getFID(onPerfEntry);
+    getFCP(onPerfEntry);
+    getLCP(onPerfEntry);
+    getTTFB(onPerfEntry);
   }
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     working_dir: /home/node/app
     environment:
       - NODE_ENV=development
+      - REACT_APP_GA_CODE="UA-129704402-1"
     volumes:
       - ./app:/home/node/app
       - ./docs:/home/node/docs


### PR DESCRIPTION
- Only if user accepted cookies
- Move GA code to environment variable (defined in docker-compose and GitHub Workflow)
- index: Emit event `webVitals` on document whenever a `webVital` is available
- App:
  - Pass `GACode` from `process.env.REACT_APP_GA_CODE` to `GAListener`
  - Add `ReportWebVitals` component to `AppProviders`
- ReportWebVitals: Cretae a new React Component to send `webVitals` document' event details to GA
- GAListener: Allow to send a custom event
- GAListenerActive:
  - Add GA script once mounted instead of in `constructor` time, using `async = true`i (with `onload` event listener) instead of `setTimeout`
  - Add `console.log` to all beacons sent to GA (location change and language change), so the user can be aware of what is beeing sent to Google