### PR TITLE
Move Service Worker updating mechanism to a component HOC

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10"
+    "@testing-library/user-event": "^12.1.10",
+    "jest-canvas-mock": "^2.3.1"
   }
 }

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   HashRouter as Router,
   Route,
@@ -96,10 +95,8 @@ class App extends React.Component {
     // Save App element to handle modal
     this.appElement = React.createRef();
 
-    this.registration = false;
     this.state = {
       initializing: true,
-      newServiceWorkerDetected: false,
       language: available.hasOwnProperty(navigator.language) ? navigator.language : 'en-en',
       trackingSeen: false,
       trackOptIn: !this.dnt,
@@ -108,30 +105,17 @@ class App extends React.Component {
     };
   }
 
-  componentDidMount() {
-    document.addEventListener('onNewServiceWorker', this.handleNewServiceWorker);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('onNewServiceWorker', this.handleNewServiceWorker);
-  }
-
-  handleNewServiceWorker = (event) => {
-    this.registration = event.detail.registration;
-    this.setState({
-      newServiceWorkerDetected: true,
-    });
-  }
-
   handleStopInitializing = () => {
     this.setState({ initializing: false });
   }
+
+  handleLanguageChange = (language) => this.setState({ language });
 
 
   render() {
     const date = new Date();
     const todayStr = `/${date.getFullYear()}/${1 + date.getMonth()}/${date.getDate()}/0/0`;
-    const { newServiceWorkerDetected, language, trackOptIn, trackingSeen, initializing } = this.state;
+    const { language, trackOptIn, trackingSeen, initializing } = this.state;
     const translations = available[language];
 
 
@@ -148,7 +132,7 @@ class App extends React.Component {
         <Storage
           parent={ this }
           prefix='App'
-          blacklist={ ['newServiceWorkerDetected', 'initializing'] }
+          blacklist={ ['initializing'] }
           onParentStateHydrated={ this.handleStopInitializing  }
         />
 
@@ -195,8 +179,6 @@ class App extends React.Component {
             {/* Menu */}
             <ErrorCatcher origin='AppMenu'>
               <AppMenu
-                newServiceWorkerDetected={ newServiceWorkerDetected }
-                onLoadNewServiceWorkerAccept={ this.handleLoadNewServiceWorkerAccept }
                 language={ language }
                 onLanguageChange={ this.handleLanguageChange }
                 trackOptIn={ trackOptIn }
@@ -257,18 +239,6 @@ class App extends React.Component {
       </AppProviders>
     )
   }
-
-  handleLoadNewServiceWorkerAccept = () => this.props.onLoadNewServiceWorkerAccept(this.registration);
-
-  handleLanguageChange = (language) => this.setState({ language });
 }
-
-App.defaultProps = {
-  onLoadNewServiceWorkerAccept: registration => {},
-};
-
-App.propTypes = {
-  onLoadNewServiceWorkerAccept: PropTypes.func.isRequired,
-};
 
 export default App;

--- a/app/src/AppMenu.jsx
+++ b/app/src/AppMenu.jsx
@@ -26,6 +26,7 @@ import {
 } from 'react-burger-menu'
 
 import { withGAEvent } from './GAListener';
+import withServiceWorkerUpdater from './withServiceWorkerUpdater';
 import './AppMenu.css';
 
 class AppMenu extends React.Component {
@@ -254,4 +255,10 @@ AppMenu.propTypes = {
   sendEvent: PropTypes.func.isRequired,
 };
 
-export default translate('AppMenu')(withGAEvent(AppMenu));
+export default translate('AppMenu')(
+  withGAEvent(
+    withServiceWorkerUpdater(
+      AppMenu
+    )
+  )
+);

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -6,45 +6,19 @@ import App from './App';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+
 // Creates a custom event and fires it on the document
 // Internal components can listen to it
 const dispatchCustomEvent = (name, detail) => {
   const event = new CustomEvent(name, { detail });
   document.dispatchEvent(event);
 }
-
-// Callback to call when user accepts loading new service worker
-// - Send message to SW to trigger the update
-// - Once updated, reload this window to load new assets
-const updateSW = (registration) => {
-  if( registration.waiting ) {
-
-    // When the user asks to refresh the UI, we'll need to reload the window
-    var preventDevToolsReloadLoop;
-    navigator.serviceWorker.addEventListener('controllerchange', function(event) {
-
-      // Ensure refresh is only called once.
-      // This works around a bug in "force update on reload".
-      if (preventDevToolsReloadLoop) {
-        return;
-      }
-
-      preventDevToolsReloadLoop = true;
-      console.log('Controller loaded');
-      global.location.reload(true);
-    });
-
-    // Send a message to the new serviceWorker to activate itself
-    registration.waiting.postMessage({type: 'SKIP_WAITING'});
-  }
-};
-
-ReactDOM.render(
-  <React.StrictMode>
-    <App onLoadNewServiceWorkerAccept={ updateSW } />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/app/src/setupTests.js
+++ b/app/src/setupTests.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import 'jest-canvas-mock';

--- a/app/src/withServiceWorkerUpdater.jsx
+++ b/app/src/withServiceWorkerUpdater.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+// Callback to call when user accepts loading new service worker
+// - Send message to SW to trigger the update
+// - Once updated, reload this window to load new assets
+const updateSW = (registration) => {
+  if( registration.waiting ) {
+    // When the user asks to refresh the UI, we'll need to reload the window
+    let preventDevToolsReloadLoop;
+    navigator.serviceWorker.addEventListener('controllerchange', (event) => {
+
+      // Ensure refresh is only called once.
+      // This works around a bug in "force update on reload".
+      if (preventDevToolsReloadLoop) {
+        return;
+      }
+
+      preventDevToolsReloadLoop = true;
+      console.log('Controller loaded');
+      global.location.reload(true);
+    });
+
+    // Send a message to the new serviceWorker to activate itself
+    registration.waiting.postMessage({type: 'SKIP_WAITING'});
+  }
+};
+
+const withServiceWorkerUpdater = (WrappedComponent) =>
+  (props) => {
+    const [registration, setRegistration] = React.useState(false);
+    const [newServiceWorkerDetected, setNewServiceWorkerDetected] = React.useState(false);
+    const handleLoadNewServiceWorkerAccept = () => {
+      updateSW(registration);
+    }
+
+    // Add/remove event listeners for event thrown from `index.js`
+    React.useEffect(() => {
+      const handleNewServiceWorker = (event) => {
+        setRegistration(event.detail.registration);
+        setNewServiceWorkerDetected(true);
+      }
+
+      document.addEventListener('onNewServiceWorker', handleNewServiceWorker);
+      return () => document.removeEventListener('onNewServiceWorker', handleNewServiceWorker);
+    }, [setRegistration, setNewServiceWorkerDetected]);
+
+    return <WrappedComponent
+      {...props}
+      newServiceWorkerDetected={ newServiceWorkerDetected }
+      onLoadNewServiceWorkerAccept={ handleLoadNewServiceWorkerAccept }
+    />;
+  }
+
+export default withServiceWorkerUpdater;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3382,7 +3382,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -3823,6 +3823,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -6339,6 +6344,14 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jest-canvas-mock@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz#9535d14bc18ccf1493be36ac37dd349928387826"
+  integrity sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
@@ -7456,6 +7469,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moo-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"
+  integrity sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==
+  dependencies:
+    color-name "^1.1.4"
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   rac1:
     container_name: rac1
-    image: node:12-slim
+    image: node:14
     user: "node"
     working_dir: /home/node/app
     environment:


### PR DESCRIPTION
- Create a HOC which (code moved from `App.js`):
  - Adds/removes event listeners from document listening for `onNewServiceWorker` (emitted from `index.js`)
  - Stores the status of a new service worker detected
  - Passes the acceptation callback and the status to the Wrapped component via props
- Use the HOC directly where needed: in `AppMenu.jsx`
